### PR TITLE
Reinstate hlm_model_day fix from CTSM PR 820

### DIFF
--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -2,7 +2,7 @@
 local_path = src/fates
 protocol = git
 repo_url = https://github.com/NGEET/fates
-tag = sci.1.36.0_api.11.2.0
+tag = sci.1.40.0_api.13.0.0
 required = True
 
 [PTCLM]


### PR DESCRIPTION
This patch reinstates the hlm_model_day fix in which lawrencium was catching uninitialized variables via the `-ftrapuv` compiler setting.  It appears the [original PR](https://github.com/ESCOMP/CTSM/pull/820) was lost during this merge of release-clm5.0.30: https://github.com/ESCOMP/CTSM/commit/f148eb16ff840fb310682b8c05aa307f090e9c25#diff-d5aa89e69afc455e4e84461df1cfa3b6. 

This code has already been tested in conjunction with the regression tests here: https://github.com/NGEET/fates/pull/663#issuecomment-662760793

This PR also updates the externals configuration to point to the expected new fates tag.